### PR TITLE
Update shard dependencies.

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -41,6 +41,12 @@ Lint/LiteralInCondition:
   Enabled: true
   Severity: Warning
 
+Lint/MissingBlockArgument:
+  Enabled: false
+
+Lint/NotNil:
+  Enabled: false
+
 # Problems found: 18
 # Run `ameba --only Lint/UselessAssign` for details
 Lint/UselessAssign:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Crystal
         uses: MeilCli/setup-crystal-action@master
         with:
-          crystal_version: 1.0.0
+          crystal_version: latest
           shards_version: latest
 
       - name: Install dependencies

--- a/shard.yml
+++ b/shard.yml
@@ -6,31 +6,28 @@ authors:
 
 license: LGPL-3.0
 
-crystal: ">= 1.0.0"
+crystal: ">= 1.6.0"
 
 dependencies:
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 2.6
+    version: ">= 2.6"
   kemal:
     github: kemalcr/kemal
-    version: "~> 1.3.0"
+    version: ">= 1.3.0"
   kemal-session:
     github: kemalcr/kemal-session
-    version: "~> 1.0.0"
+    version: ">= 1.0.0"
   kemal-csrf:
     github: kemalcr/kemal-csrf
-    # version: ~> 0.8.0
-    commit: abaee30f1e8e28d896ed6bf5267a530b5d6ca638
+    version: ">= 1.0.0"
   baked_file_system:
     github: schovi/baked_file_system
-    # version: ~> 0.9.8
-    commit: 7183bfd
+    version: ">= 0.10.0"
 
 development_dependencies:
   timecop:
     github: crystal-community/timecop.cr
-    version: ~> 0.4.1
+    version: ">= 0.5.0"
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.2

--- a/src/sidekiq/api.cr
+++ b/src/sidekiq/api.cr
@@ -79,7 +79,8 @@ module Sidekiq
       workers_size = sizes[0...s].sum
       enqueued = sizes[s..-1].sum
 
-      default_queue_latency = if (entry = pipe1_res[6].as(Array(Redis::RedisValue)).first?)
+      entry = pipe1_res[6].as(Array(Redis::RedisValue)).first?
+      default_queue_latency = if entry
                                 hash = JSON.parse(entry.as(String))
                                 was = hash["enqueued_at"].as_f
                                 Time.local.to_unix_f - was

--- a/src/sidekiq/client.cr
+++ b/src/sidekiq/client.cr
@@ -51,7 +51,7 @@ module Sidekiq
     #     chain.use MyClientMiddleware
     #   end
     #
-    def middleware(&block)
+    def middleware
       yield @chain
       @chain
     end


### PR DESCRIPTION
Specify just the minimal version of dependencies that are expected to work, so we don't lock the version of anyone that also depends on these libs in their projects.

In case of some future version of these dependencies don't work with sidekiq, a bug will be filledand we can fix it, so everybody will be always happy.