### PR TITLE
Remove ameba from development dependencies and use it as a Github action instead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@master
 
+      - name: Crystal Ameba Linter
+        uses: crystal-ameba/github-action@v0.7.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Crystal
         uses: MeilCli/setup-crystal-action@master
         with:
@@ -32,9 +37,6 @@ jobs:
 
       - name: Check Formatting
         run: crystal tool format --check
-
-      - name: Run Ameba
-        run: ./bin/ameba
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/shard.yml
+++ b/shard.yml
@@ -29,5 +29,3 @@ development_dependencies:
   timecop:
     github: crystal-community/timecop.cr
     version: ">= 0.5.0"
-  ameba:
-    github: crystal-ameba/ameba


### PR DESCRIPTION
So people don't need to wait for ameba being compiled when running shards install.